### PR TITLE
chore: upgrade to Spring Boot 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Originally developed for [spring-data-mongodb-encrypt](https://github.com/bolcom
 Add dependency:
 
 ```xml
-        <dependency>
-            <groupId>com.bol</groupId>
-            <artifactId>cryptvault</artifactId>
-            <version>1.0.2</version>
-        </dependency>
+<dependency>
+    <groupId>com.bol</groupId>
+    <artifactId>cryptvault</artifactId>
+    <version>1.0.2</version>
+</dependency>
 ```
 
 And add the following to your `application.yml`:
@@ -41,15 +41,15 @@ And you're done!
 Example usage:
 
 ```java
-    @Autowired CryptVault cryptVault;
+@Autowired CryptVault cryptVault;
 
-    // encrypt
-    byte[] encrypted = cryptVault.encrypt("rock".getBytes());
+// encrypt
+byte[] encrypted = cryptVault.encrypt("rock".getBytes());
 
-    // decrypt
-    byte[] decrypted = cryptVault.decrypt(encrypted);
-    
-    new String(decrypted).equals("rock");   // true 
+// decrypt
+byte[] decrypted = cryptVault.decrypt(encrypted);
+
+new String(decrypted).equals("rock");   // true 
 ```
 
 ## Manual configuration

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>cryptvault</artifactId>
     <packaging>jar</packaging>
     <name>cryptvault</name>
-    <version>1.0.2</version>
+    <version>3-1.0.2</version>
     <description>Versioned crypto library</description>
     <url>https://github.com/bolcom/cryptvault</url>
 
@@ -43,26 +43,26 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>2.4.0</version>
+            <version>3.2.3</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.4.0</version>
+            <version>3.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.18.1</version>
+            <version>3.25.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/bol/config/CryptVaultAutoConfiguration.java
+++ b/src/main/java/com/bol/config/CryptVaultAutoConfiguration.java
@@ -1,16 +1,16 @@
 package com.bol.config;
 
 import com.bol.crypt.CryptVault;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
 import java.util.List;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnProperty("cryptvault.keys[0].key")
 public class CryptVaultAutoConfiguration {
 

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.bol.config.CryptVaultAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.bol.config.CryptVaultAutoConfiguration


### PR DESCRIPTION
Spring Boot 3 made some changes to the way a library, such as this one,
notifies Spring Boot that it wants to be autoconfigured.

[Details of this change are in the release notes of version 2.7][1].

With this commit, a new versioning system for this package is proposed:
`<Spring Boot version>-<tradition semantic versioning>`. For example,
`3-1.0.2`. Why? The problem with only semantic versioning _and_
following Spring releases (especially those with breaking changes) is,
that it becomes unclear when to update to a new major version. Should we
do it when this library introduces a breaking change? Or when Spring
Boot does? To solve this, the version now consists of a leading digit,
indicating the Spring Boot version that this version works with,
followed by a semantic version of the library itself.

So, we now have `2-1.0.2`, working with Spring Boot 2, alongside
`3-1.0.2`, which works with Spring Boot 3. When a breaking change is
made to this library, we would signal that by bumping the versions to
`2-2.0.0` and `3-2.0.0`, respectively.

[1]: <https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#changes-to-auto-configuration>