### PR TITLE
feat: allow using ciphers with no IV or the same IV for every encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add dependency:
 <dependency>
     <groupId>com.bol</groupId>
     <artifactId>cryptvault</artifactId>
-    <version>1.0.2</version>
+    <version>3-1.0.2</version>
 </dependency>
 ```
 
@@ -93,4 +93,7 @@ to override which version of the defined keys is considered 'default'.
 
 ## Expected size of encrypted data
 
-Depending on how much padding is used, you can expect 17..33 bytes for encryption overhead (salt + padding).
+Depending on the cipher, whether an IV is used and the padding scheme you must
+expect some overhead for encryption. The default cipher, AES-256-CBC with PKCS
+#5 padding, requires an extra [18, 33] bytes: version (1) + IV (16) + padding
+(best case: 1, worst case: 16).

--- a/src/main/java/com/bol/config/CryptVaultAutoConfiguration.java
+++ b/src/main/java/com/bol/config/CryptVaultAutoConfiguration.java
@@ -21,7 +21,7 @@ public class CryptVaultAutoConfiguration {
 
         for (Key key : properties.keys) {
             byte[] secretKeyBytes = Base64.getDecoder().decode(key.key);
-            cryptVault.with256BitAesCbcPkcs5PaddingAnd128BitSaltKey(key.version, secretKeyBytes);
+            cryptVault.with256BitAesCbcPkcs5PaddingAnd16ByteIv(key.version, secretKeyBytes);
         }
 
         if (properties.defaultKey != null) {

--- a/src/main/java/com/bol/crypt/CryptVersion.java
+++ b/src/main/java/com/bol/crypt/CryptVersion.java
@@ -3,17 +3,29 @@ package com.bol.crypt;
 import java.security.Key;
 import java.util.function.Function;
 
-/** Immutable data class */
 public class CryptVersion {
-    public final int saltLength;
+    public final int version;
+    public final int ivLength;
     public final String cipher;
     public final Key key;
-    public final Function<Integer, Integer> encryptedLength;
+    public final Function<Integer, Integer> ciphertextLength;
 
-    public CryptVersion(int saltLength, String cipher, Key key, Function<Integer, Integer> encryptedLength) {
-        this.saltLength = saltLength;
+    /**
+     * @param version          The version number of these crypto settings. Stored in a byte, so should be [0,255].
+     * @param ivLength         Length of the IV to use in bytes. For AES, if an IV is required, this should be equal to the block size (16). If 0, no IV will be used. Use this with ECB mode of operation, for example.
+     * @param cipher           Name of the cipher, e.g. "AES/CTR/NoPadding".
+     * @param key              The secret key.
+     * @param ciphertextLength Length of the resultant ciphertext in bytes.
+     */
+    public CryptVersion(int version, int ivLength, String cipher, Key key, Function<Integer, Integer> ciphertextLength) {
+        this.version = version;
+        this.ivLength = ivLength;
         this.cipher = cipher;
         this.key = key;
-        this.encryptedLength = encryptedLength;
+        this.ciphertextLength = ciphertextLength;
+    }
+
+    public boolean requiresIv() {
+        return ivLength > 0;
     }
 }


### PR DESCRIPTION
This commit enables modes of operation that do not require an IV, such
as ECB. It also allows reusing of IVs. This is not recommended if it can
be avoided, because if the (first few blocks of) plaintext are the same,
the (first few blocks of) the ciphertext will be the same, thus
disclosing information. However, this can be useful to implement a form
of "searchable encryption", where one can search whether a string is
present without having to decrypt all ciphertexts first.

This commit also renames references to "salt" with "IV". A salt is some
random string added to a passphrase. Some algorithm (such as PBKDF2) is
then used to derive a key from this passphrase. This key is then used by
the block cipher. The salt makes sure the same passphrase does not
always result in the same key. An IV, on the other hand, is used by a
block cipher mode of operation (such as CBC) to ensure that the same
plaintext does not always encrypt to the same ciphertext. In this case,
it is clear "IV" was meant.